### PR TITLE
Fix Uncaught (in promise) null

### DIFF
--- a/src/views/recaptcha.php
+++ b/src/views/recaptcha.php
@@ -23,7 +23,7 @@ use yii\web\View;
 if ($model) {
     echo Html::activeHiddenInput($model, $attribute, ['id' => $id . '-input']);
 } else {
-    echo Html::hiddenInput($name);
+    echo Html::hiddenInput($name, null, ['id' => $id . '-input']);
 }
 
 echo Html::tag($container, '', ArrayHelper::merge($containerOptions, ['id' => $id . '-container']));


### PR DESCRIPTION
By default with using RecaptchaWidget::widget we cant specify id, that leads to hidden input without id.

In this case we got error in js:
Without id-input got Uncaught (in promise) null.
